### PR TITLE
chore: remove duplicate stamps, refactor

### DIFF
--- a/flockscan.py
+++ b/flockscan.py
@@ -222,9 +222,7 @@ json_string = json.dumps(unique_list, indent=4)
 final_array_with_url = parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucketname, aws_s3_image_dir)
 
 # Join the list items as a JSON array string
-# final_array_with_url_string = '[' + ', '.join(final_array_with_url) + ']'
 final_array_with_url_string = '[' + ', '.join(json.dumps(item) for item in final_array_with_url) + ']'
-
 
 print(final_array_with_url_string)
 with open(json_output, 'w') as f:

--- a/flockscan.py
+++ b/flockscan.py
@@ -15,6 +15,8 @@ from requests.auth import HTTPBasicAuth
 # this will exclude the initial tests with text in the string suck as stamp:"data:image/png;base64,[base64]" 
 # this exclusion / malformatting can be tested with stamps prior to block 779652
 
+aws_access_key_id = ""
+aws_secret_access_key = ""
 aws_cloudfront_distribution_id = ""
 cntrprty_user = "rpc"
 cntrprty_password = "rpc"
@@ -44,7 +46,9 @@ s3_client = boto3.client(
     's3',
     aws_access_key_id=aws_access_key_id,
     aws_secret_access_key=aws_secret_access_key
-    ) 
+    )
+
+
        
 def convert_base64_to_file(base64_string, item):
     binary_data = base64.b64decode(base64_string)
@@ -80,6 +84,10 @@ def upload_file_to_s3_aws_cli(file_path, bucket_name, s3_path):
     subprocess.run(["aws", "s3", "cp", file_path, f"s3://{bucket_name}/{s3_path}"], stdout=subprocess.DEVNULL)
     return True
 
+def upload_file_to_s3_boto3(file_path, bucket_name, s3_key, s3_client):
+    with open(file_path, 'rb') as f:
+        s3_client.upload_fileobj(f, bucket_name, s3_key)
+
 def convert_json_array_files(json_string_array, bucket_name, s3_path):
     json_dict = json.loads(json_string_array)
     for item in json_dict:
@@ -87,7 +95,6 @@ def convert_json_array_files(json_string_array, bucket_name, s3_path):
         file_path = convert_base64_to_file(base64_string, item)
         if upload_file_to_s3_aws_cli(file_path, bucket_name, s3_path):
             os.remove(file_path)
-        
 
     return json.dumps(json_dict)
 
@@ -109,24 +116,33 @@ def get_flocks(block_indexes):
     block_data = result[i]
     messages = block_data["_messages"]
     for message in messages:
-      if message["category"] == "issuances":
+      # in message index [9142396,9142291] there is no identifying difference in the category  or command ffield
+      # only the  lock status  changed from false to true. the simplest method is to only allow the first trx of the asseet in as a stamp
+      # this also means that if a user creates an asset with lock = fales and a blank description field. then they
+      # add a stamp: formatted description and change the lock status to true it would then be counted as a stamp.
+
+      if message["category"] == "issuances" and message["command"] == "insert":
         bindings = message["bindings"]
+        # and an iff bindings["status"] == "valid"  ?
         description = json.loads(bindings)["description"]
         if description.lower().find("stamp:") != -1:
           stamp_search = description[description.lower().find("stamp:")+6:]
           stamp_base64 = stamp_search.strip() if len(stamp_search) > 1 else None  
           bindings = json.loads(bindings)
-          message["bindings"] = {
-            "description": bindings["description"],
-            "tx_hash": bindings["tx_hash"],
-            "asset": bindings["asset"],
-            "asset_longname": bindings["asset_longname"],
-            "block_index": bindings["block_index"],
-            "status": bindings["status"],
-            "tx_index": bindings["tx_index"],
-            "stamp_base64": stamp_base64 # add this line                                                       
-          }
-          output_list.append(message)
+          asset = bindings["asset"]
+          # Check if the asset already exists in the output_list
+          if not any(item["bindings"]["asset"] == asset for item in output_list):
+             message["bindings"] = {
+               "description": bindings["description"],
+               "tx_hash": bindings["tx_hash"],
+               "asset": bindings["asset"],
+               "asset_longname": bindings["asset_longname"],
+               "block_index": bindings["block_index"],
+               "status": bindings["status"],
+               "tx_index": bindings["tx_index"],
+               "stamp_base64": stamp_base64 # add this line                                                       
+             }
+             output_list.append(message)
 
   # Sort the list by message_index
   sorted_list = sorted(output_list, key=lambda k: k['message_index'])
@@ -159,6 +175,7 @@ def get_flocks(block_indexes):
 
   return flattened_list # Return the flattened list
 
+
 combined_list = []
 for i in range(0, len(blockrange), 249):
     combined_list += get_flocks(blockrange[i:i+249])
@@ -176,8 +193,22 @@ print(final_array_with_url)
 with open(json_output, 'w') as f:
     f.write(final_array_with_url)
 
+if aws_secret_access_key != "" and aws_acccess_key_id != "":
+# pending check for existing file list, we will not upload if it exists
+    s3_client = boto3.client(
+        's3',
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key
+        )
+    s3_objects = get_s3_objects(bucket_name, s3_client)
+    # s3_key should be == to stamps/txid.png
+    if s3_key not in s3_objects:
+        print(f'Uploading {local_file_path} to {s3_key}')
+        upload_file_to_s3(local_file_path, bucket_name, s3_key, s3_client)
+
+
 if aws_s3_bucketname != "" and aws_s3_dir != "" and aws_cloudfront_distribution_id != "":
     upload_file_to_s3_aws_cli(json_output,aws_s3_bucketname,"")
     # can purge local file upon successful upload
     # os.remove(json_output)
-    invalidate_s3_file("/" + aws_s3_dir + json_output)
+    invalidate_s3_file("/" + json_output)

--- a/flockscan.py
+++ b/flockscan.py
@@ -135,16 +135,17 @@ def parse_json_array_convert_base64_to_file_and_upload(json_string_array, bucket
     json_dict = json.loads(json_string_array)
     for json_component in json_dict:
         base64_string = json_component.get("stamp_base64")
-    if base64_string is not None:
-        file_path = convert_base64_to_file(base64_string, json_component)
-    else:
-        file_path = None  # or any default value that suits your use case
+        if base64_string is not None:
+            file_path = convert_base64_to_file(base64_string, json_component)
+        else:
+            file_path = None  # or any default value that suits your use case
 
-        # file_path = convert_base64_to_file(base64_string, json_component)
-        #upload_file_to_s3(file_path, bucket_name, s3_path + file_path, s3_client)
-        #os.remove(file_path)
+        if file_path:
+            upload_file_to_s3(file_path, bucket_name, s3_path + file_path, s3_client)
+            os.remove(file_path)
 
     return json.dumps(json_dict)
+
 
 def process_messages(messages):
     output_list = []

--- a/flockscan.py
+++ b/flockscan.py
@@ -205,11 +205,11 @@ unique_assets = {}
 unique_list = []
 
 for message in combined_list:
-    asset = message["asset"]
+    asset = message["bindings"]["asset"]  # Access the "asset" key from the "bindings" object
     if asset not in unique_assets:
         unique_assets[asset] = True
         unique_list.append(message)
-
+        
 # Assign new "stamp" key-value pair to the dictionary
 for i, message in enumerate(unique_list):
     message["stamp"] = i

--- a/flockscan.py
+++ b/flockscan.py
@@ -88,10 +88,6 @@ def invalidate_s3_file(file_path):
     command = ["aws", "cloudfront", "create-invalidation", "--distribution-id", aws_cloudfront_distribution_id, "--paths", file_path]
     subprocess.run(command, stdout=subprocess.DEVNULL)
 
-def upload_file_to_s3_aws_cli(local_file_path, bucket_name, s3_path):
-    subprocess.run(["aws", "s3", "cp", local_file_path, f"s3://{bucket_name}/{s3_path}"], stdout=subprocess.DEVNULL)
-    return True
-
 def upload_file_to_s3_boto3(local_file_path, bucket_name, s3_file_path, s3_client):
     try:
         with open(local_file_path, 'rb') as f:
@@ -118,8 +114,8 @@ def parse_json_array_convert_base64_to_file_and_upload(json_string_array, bucket
     for item in json_dict:
         base64_string = item.get("stamp_base64")
         file_path = convert_base64_to_file(base64_string, item)
-        if upload_file_to_s3_boto3(file_path, bucket_name, s3_path + file_path, s3_client):
-            os.remove(file_path)
+        upload_file_to_s3_boto3(file_path, bucket_name, s3_path + file_path, s3_client)
+        os.remove(file_path)
 
     return json.dumps(json_dict)
 
@@ -213,7 +209,7 @@ for message in combined_list:
 
 json_string = json.dumps(combined_list, indent=4)
 final_array_with_url=(parse_json_array_convert_base64_to_file_and_upload(json_string,aws_s3_bucketname,aws_s3_image_dir))
-print(final_array_with_url)
+#print(final_array_with_url)
 
 
 with open(json_output, 'w') as f:

--- a/flockscan.py
+++ b/flockscan.py
@@ -136,15 +136,20 @@ def parse_json_array_convert_base64_to_file_and_upload(json_string_array, bucket
     for json_component in json_dict:
         base64_string = json_component.get("stamp_base64")
         if base64_string is not None:
-            file_path = convert_base64_to_file(base64_string, json_component)
+            filename = convert_base64_to_file(base64_string, json_component)
         else:
-            file_path = None  # or any default value that suits your use case
+            filename = None
 
-        if file_path:
-            upload_file_to_s3(file_path, bucket_name, s3_path + file_path, s3_client)
-            os.remove(file_path)
+        if filename:
+            if diskless:
+                with open(filename, "rb") as file_obj:
+                    upload_file_to_s3(file_obj, bucket_name, s3_path + filename, s3_client, diskless=True)
+            else:
+                upload_file_to_s3(filename, bucket_name, s3_path + filename, s3_client)
+                os.remove(filename)
 
     return json.dumps(json_dict)
+
 
 
 def process_messages(messages):

--- a/flockscan.py
+++ b/flockscan.py
@@ -97,9 +97,12 @@ def upload_file_to_s3_aws_cli(local_file_path, bucket_name, s3_path):
     subprocess.run(["aws", "s3", "cp", local_file_path, f"s3://{bucket_name}/{s3_path}"], stdout=subprocess.DEVNULL)
     return True
 
-def upload_file_to_s3_boto3(local_file_path, bucket_name, s3_key, s3_client):
-    with open(local_file_path, 'rb') as f:
-        s3_client.upload_fileobj(f, bucket_name, s3_key)
+def upload_file_to_s3_boto3(local_file_path, bucket_name, s3_file_path, s3_client):
+    try:
+        with open(local_file_path, 'rb') as f:
+            s3_client.upload_fileobj(f, bucket_name, s3_file_path)
+    except Exception as e:
+        print("failure uploading to aws {}".format(e))
 
 def upload_raw_data_to_s3(data_stream, bucket_name, target_fileloc_name):
     # this is for aws lambda since it can't write to disk
@@ -225,7 +228,7 @@ if aws_secret_access_key != "" and aws_access_key_id != "":
 # pending check for existing file list, we will not upload if it exists
     s3_objects = get_s3_objects(aws_s3_bucketname, s3_client)
     # s3_key should be == to stamps/txid.png
-    print(s3_objects)
+    #print(s3_objects)
     #if s3_key not in s3_objects:
     #    print(f'Uploading {local_file_path} to {s3_key}')
     #    upload_file_to_s3_boto3(local_file_path, bucket_name, s3_key, s3_client)
@@ -234,7 +237,7 @@ if aws_secret_access_key != "" and aws_access_key_id != "":
 # upload json file to root dir of s3 bucket
 if aws_s3_bucketname != "" and aws_cloudfront_distribution_id != "":
     # upload_file_to_s3_aws_cli(json_output,aws_s3_bucketname,"")
-    upload_file_to_s3_boto3(json_output,aws_s3_bucketname,"/" + json_output,s3_client)
+    upload_file_to_s3_boto3(json_output,aws_s3_bucketname,json_output,s3_client)
     # can purge local file upon successful upload
     # os.remove(json_output)
     invalidate_s3_file("/" + json_output)

--- a/flockscan.py
+++ b/flockscan.py
@@ -168,7 +168,7 @@ def parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucke
                         with io.BytesIO(imgdata) as file_obj:
                             try:
                                 s3.upload_fileobj(file_obj, aws_s3_bucketname, f"{aws_s3_image_dir}/{filename}")
-                                print(f"Processed filename: {filename}")
+                                # print(f"Processed filename: {filename}") # Debug Output
                                 item["stamp_url"] = f"https://stampchain.io/stamps/{filename}"
                                 valid_json_components.append(json_component)
                             except NoCredentialsError as e:
@@ -182,7 +182,7 @@ def parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucke
         else:
             print(f"Removed invalid component: {json_component}")
 
-    print(f"Final valid_json_components: {valid_json_components}")
+    #print(f"Final valid_json_components: {json.dumps(valid_json_components, indent=4)}")
     return valid_json_components
 
 
@@ -259,13 +259,15 @@ for i, message in enumerate(unique_list):
     message["stamp"] = i
 
 json_string = json.dumps(unique_list, indent=4)
-final_array_with_url = (parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucketname, aws_s3_image_dir))
-print(final_array_with_url)
+final_array_with_url = parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucketname, aws_s3_image_dir)
 
+# Join the list items as a JSON array string
+final_array_with_url_string = '[' + ', '.join(final_array_with_url) + ']'
 
-
+print(final_array_with_url_string)
 with open(json_output, 'w') as f:
-    f.write(final_array_with_url)
+    f.write(final_array_with_url_string)
+
 
 if aws_secret_access_key != "" and aws_access_key_id != "":
 # pending check for existing file list, we will not upload if it exists

--- a/flockscan.py
+++ b/flockscan.py
@@ -170,7 +170,7 @@ def parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucke
                                 s3.upload_fileobj(file_obj, aws_s3_bucketname, f"{aws_s3_image_dir}/{filename}")
                                 # print(f"Processed filename: {filename}") # Debug Output
                                 item["stamp_url"] = f"https://stampchain.io/stamps/{filename}"
-                                valid_json_components.append(json_component)
+                                valid_json_components.append(item)
                             except NoCredentialsError as e:
                                 print(f"Unable to upload {filename} to S3. Error: {e}")
                     except Exception as e:
@@ -264,7 +264,9 @@ json_string = json.dumps(unique_list, indent=4)
 final_array_with_url = parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucketname, aws_s3_image_dir)
 
 # Join the list items as a JSON array string
-final_array_with_url_string = '[' + ', '.join(final_array_with_url) + ']'
+# final_array_with_url_string = '[' + ', '.join(final_array_with_url) + ']'
+final_array_with_url_string = '[' + ', '.join(json.dumps(item) for item in final_array_with_url) + ']'
+
 
 print(final_array_with_url_string)
 with open(json_output, 'w') as f:

--- a/flockscan.py
+++ b/flockscan.py
@@ -40,7 +40,8 @@ json_output = "stamp.json"
 
 # the first official stamps
 blockstart = 779652
-blockend = int(subprocess.check_output(['fednode', 'exec', 'bitcoin', 'bitcoin-cli', 'getblockcount']).decode('utf-8'))
+blockend = requests.get('https://blockchain.info/q/getblockcount').json()
+# blockend = int(subprocess.check_output(['fednode', 'exec', 'bitcoin', 'bitcoin-cli', 'getblockcount']).decode('utf-8'))
 blockrange = list(range(blockstart,blockend))
 
 # API VARS
@@ -228,9 +229,10 @@ if aws_secret_access_key != "" and aws_access_key_id != "":
         upload_file_to_s3_boto3(local_file_path, bucket_name, s3_key, s3_client)
 
 
+# upload json file to root dir of s3 bucket
 if aws_s3_bucketname != "" and aws_s3_dir != "" and aws_cloudfront_distribution_id != "":
     # upload_file_to_s3_aws_cli(json_output,aws_s3_bucketname,"")
-    upload_file_to_s3_boto3(json_output,aws_s3_bucketname,aws_s3_dir,s3_client)
+    upload_file_to_s3_boto3(json_output,aws_s3_bucketname,"/" + json_output,s3_client)
     # can purge local file upon successful upload
     # os.remove(json_output)
     invalidate_s3_file("/" + json_output)

--- a/flockscan.py
+++ b/flockscan.py
@@ -23,7 +23,7 @@ cntrprty_user = "rpc"
 cntrprty_password = "rpc"
 cntrprty_api_url = "http://127.0.0.1:4000/api/"
 blockchain_api_url = "https://blockchain.info/"
-diskless = True # if True, will not save stamps to disk
+diskless = False # if True, will not save stamps to disk
 
 # import private vars, may over-ride the above
 if os.path.exists('private_vars.py'):
@@ -61,10 +61,9 @@ def convert_base64_to_file(base64_string, item):
     _, file_extension = file_type.split("/")
     tx_hash = item.get("tx_hash")
     filename = f"{tx_hash}.{file_extension}"
+    s3_file_path = aws_s3_image_dir + filename
     if diskless:
         # write the file directly to s3
-        print("writing to s3")
-        s3_file_path = aws_s3_image_dir + filename
         upload_file_to_s3(binary_data, aws_s3_bucketname, s3_file_path, s3_client)
     else:
         # write the file to disk

--- a/flockscan.py
+++ b/flockscan.py
@@ -171,17 +171,31 @@ def process_messages(messages):
     return output_list
 
 
-combined_list = []
-for i in range(0, len(blockrange), 249):
-    block_indexes = blockrange[i:i + 249]
+def get_block_data(block_indexes):
+    payload = {
+        "method": "get_blocks",
+        "params": {
+            "block_indexes": block_indexes
+        },
+        "jsonrpc": "2.0",
+        "id": 0
+    }
     response = requests.post(cntrprty_api_url, data=json.dumps(payload), headers=headers, auth=auth)
     output = response.text
     data = json.loads(output)
-    result = data["result"]
+    return data["result"]
+
+
+combined_list = []
+for i in range(0, len(blockrange), 249):
+    block_indexes = blockrange[i:i + 249]
+    result = get_block_data(block_indexes)
 
     for block_data in result:
         messages = block_data["_messages"]
         combined_list += process_messages(messages)
+
+# ... rest of the code
 
 # Sort the combined_list by message_index
 combined_list = sorted(combined_list, key=lambda k: k['message_index'])

--- a/flockscan.py
+++ b/flockscan.py
@@ -154,10 +154,10 @@ def parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucke
     for item in json_data:
         json_component = json.dumps(item)
         if item.get("command") == "insert" and item.get("category") == "issuances":
-            bindings = item.get("bindings")
-            if bindings:
-                stamp_base64 = bindings.get("stamp_base64")
-                tx_hash = bindings.get("tx_hash")
+            #bindings = item.get("bindings")
+            #if bindings:
+                stamp_base64 = item.get("stamp_base64")
+                tx_hash = item.get("tx_hash")
                 
                 if stamp_base64 and tx_hash:
                     try:
@@ -177,8 +177,8 @@ def parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucke
                         print(f"Error processing base64 image for {tx_hash}: {e}")
                 else:
                     print(f"Removed invalid component: {json_component}")
-            else:
-                print(f"Removed invalid component: {json_component}")
+            #else:
+            #    print(f"Removed invalid component: {json_component}")
         else:
             print(f"Removed invalid component: {json_component}")
 
@@ -254,9 +254,11 @@ for message in combined_list:
         unique_assets[asset] = True
         unique_list.append(message)
 
-# Assign new "stamp" key-value pair to the dictionary
+# Assign new "stamp" key-value pair to the dictionary and flatten
 for i, message in enumerate(unique_list):
     message["stamp"] = i
+    bindings = message.pop("bindings")
+    message.update(bindings)
 
 json_string = json.dumps(unique_list, indent=4)
 final_array_with_url = parse_json_array_convert_base64_to_file_and_upload(json_string, aws_s3_bucketname, aws_s3_image_dir)

--- a/flockscan.py
+++ b/flockscan.py
@@ -135,7 +135,12 @@ def parse_json_array_convert_base64_to_file_and_upload(json_string_array, bucket
     json_dict = json.loads(json_string_array)
     for json_component in json_dict:
         base64_string = json_component.get("stamp_base64")
+    if base64_string is not None:
         file_path = convert_base64_to_file(base64_string, json_component)
+    else:
+        file_path = None  # or any default value that suits your use case
+
+        # file_path = convert_base64_to_file(base64_string, json_component)
         #upload_file_to_s3(file_path, bucket_name, s3_path + file_path, s3_client)
         #os.remove(file_path)
 
@@ -209,7 +214,7 @@ for message in combined_list:
     if asset not in unique_assets:
         unique_assets[asset] = True
         unique_list.append(message)
-        
+
 # Assign new "stamp" key-value pair to the dictionary
 for i, message in enumerate(unique_list):
     message["stamp"] = i

--- a/flockscan.py
+++ b/flockscan.py
@@ -18,7 +18,8 @@ aws_secret_access_key = ""
 aws_cloudfront_distribution_id = ""
 cntrprty_user = "rpc"
 cntrprty_password = "rpc"
-cntrprty_api_url = "http://api.counterparty.io:4000/api/"
+cntrprty_api_url = "http://127.0.0.1:4000/api/"
+blockchain_api_url = "https://blockchain.info/"
 diskless = False # if True, will not save stamps to disk
 
 # import private vars, may over-ride the above
@@ -27,7 +28,7 @@ if os.path.exists('private_vars.py'):
 
 # if the aws_cloudfront_distribution_id is not set these will be ignored
 aws_s3_bucketname = "stampchain.io"
-aws_s3_dir = "stamps/"
+aws_s3_image_dir = "stamps/"
 s3_client = boto3.client(
     's3',
     aws_access_key_id=aws_access_key_id,
@@ -40,7 +41,7 @@ json_output = "stamp.json"
 
 # the first official stamps
 blockstart = 779652
-blockend = requests.get('https://blockchain.info/q/getblockcount').json()
+blockend = requests.get(blockchain_api_url + 'q/getblockcount').json()
 # blockend = int(subprocess.check_output(['fednode', 'exec', 'bitcoin', 'bitcoin-cli', 'getblockcount']).decode('utf-8'))
 blockrange = list(range(blockstart,blockend))
 
@@ -73,7 +74,7 @@ def convert_base64_to_file(base64_string, item):
         with open(filename, "wb") as f:
             f.write(binary_data)
     # save the url back to the array
-    item["stamp_url"] = "https://" + aws_s3_bucketname + "/" + aws_s3_dir  + filename
+    item["stamp_url"] = "https://" + aws_s3_bucketname + "/" + aws_s3_image_dir  + filename
     return filename
 
 def get_s3_objects(bucket_name, s3_client):
@@ -213,7 +214,7 @@ for message in combined_list:
 
 
 json_string = json.dumps(combined_list, indent=4)
-final_array_with_url=(parse_json_array_convert_base64_to_file_and_upload(json_string,aws_s3_bucketname,aws_s3_dir))
+final_array_with_url=(parse_json_array_convert_base64_to_file_and_upload(json_string,aws_s3_bucketname,aws_s3_image_dir))
 print(final_array_with_url)
 
 

--- a/flockscan.py
+++ b/flockscan.py
@@ -225,13 +225,14 @@ if aws_secret_access_key != "" and aws_access_key_id != "":
 # pending check for existing file list, we will not upload if it exists
     s3_objects = get_s3_objects(aws_s3_bucketname, s3_client)
     # s3_key should be == to stamps/txid.png
-    if s3_key not in s3_objects:
-        print(f'Uploading {local_file_path} to {s3_key}')
-        upload_file_to_s3_boto3(local_file_path, bucket_name, s3_key, s3_client)
+    print(s3_objects)
+    #if s3_key not in s3_objects:
+    #    print(f'Uploading {local_file_path} to {s3_key}')
+    #    upload_file_to_s3_boto3(local_file_path, bucket_name, s3_key, s3_client)
 
 
 # upload json file to root dir of s3 bucket
-if aws_s3_bucketname != "" and aws_s3_dir != "" and aws_cloudfront_distribution_id != "":
+if aws_s3_bucketname != "" and aws_cloudfront_distribution_id != "":
     # upload_file_to_s3_aws_cli(json_output,aws_s3_bucketname,"")
     upload_file_to_s3_boto3(json_output,aws_s3_bucketname,"/" + json_output,s3_client)
     # can purge local file upon successful upload

--- a/flockscan.py
+++ b/flockscan.py
@@ -1,5 +1,3 @@
-
-
 import json
 import time
 import base64
@@ -21,6 +19,7 @@ aws_cloudfront_distribution_id = ""
 cntrprty_user = "rpc"
 cntrprty_password = "rpc"
 cntrprty_api_url = "http://api.counterparty.io:4000/api/"
+diskless = False # if True, will not save stamps to disk
 
 # import private vars, may over-ride the above
 if os.path.exists('private_vars.py'):
@@ -29,6 +28,12 @@ if os.path.exists('private_vars.py'):
 # if the aws_cloudfront_distribution_id is not set these will be ignored
 aws_s3_bucketname = "stampchain.io"
 aws_s3_dir = "stamps/"
+s3_client = boto3.client(
+    's3',
+    aws_access_key_id=aws_access_key_id,
+    aws_secret_access_key=aws_secret_access_key
+    )
+
 
 # saved in script dir
 json_output = "stamp.json"
@@ -59,8 +64,14 @@ def convert_base64_to_file(base64_string, item):
     _, file_extension = file_type.split("/")
     tx_hash = item.get("tx_hash")
     filename = f"{tx_hash}.{file_extension}"
-    with open(filename, "wb") as f:
-        f.write(binary_data)
+    if diskless:
+        # write the file directly to s3
+        print("writing to s3")
+    else:
+        # write the file to disk - update to send data_stream to s3 directly
+        with open(filename, "wb") as f:
+            f.write(binary_data)
+    # save the url back to the array
     item["stamp_url"] = "https://" + aws_s3_bucketname + "/" + aws_s3_dir  + filename
     return filename
 
@@ -80,15 +91,29 @@ def invalidate_s3_file(file_path):
     command = ["aws", "cloudfront", "create-invalidation", "--distribution-id", aws_cloudfront_distribution_id, "--paths", file_path]
     subprocess.run(command, stdout=subprocess.DEVNULL)
 
-def upload_file_to_s3_aws_cli(file_path, bucket_name, s3_path):
-    subprocess.run(["aws", "s3", "cp", file_path, f"s3://{bucket_name}/{s3_path}"], stdout=subprocess.DEVNULL)
+def upload_file_to_s3_aws_cli(local_file_path, bucket_name, s3_path):
+    subprocess.run(["aws", "s3", "cp", local_file_path, f"s3://{bucket_name}/{s3_path}"], stdout=subprocess.DEVNULL)
     return True
 
-def upload_file_to_s3_boto3(file_path, bucket_name, s3_key, s3_client):
-    with open(file_path, 'rb') as f:
+def upload_file_to_s3_boto3(local_file_path, bucket_name, s3_key, s3_client):
+    with open(local_file_path, 'rb') as f:
         s3_client.upload_fileobj(f, bucket_name, s3_key)
 
-def convert_json_array_files(json_string_array, bucket_name, s3_path):
+def upload_raw_data_to_s3(data_stream, bucket_name, target_fileloc_name):
+    # this is for aws lambda since it can't write to disk
+    # target_fileloc_name is the complete path and filename in s3
+    s3_client.upload_fileobj(data_stream, bucket_name, target_fileloc_name)
+    # # example usage:
+    # # Create an in-memory stream
+    # data_stream = io.BytesIO()
+    # # Write the data array to the stream
+    # data_stream.write(json.dumps(json_output))
+    # # Reset the stream position
+    # data_stream.seek(0)
+    # # Pass the filename and stream to the upload_file_to_s3 function
+    # upload_raw_data_to_s3(data_stream, bucket_name,target_fileloc_name, )
+
+def parse_json_array_convert_base64_to_file_and_upload(json_string_array, bucket_name, s3_path):
     json_dict = json.loads(json_string_array)
     for item in json_dict:
         base64_string = item.get("stamp_base64")
@@ -187,28 +212,25 @@ for message in combined_list:
 
 
 json_string = json.dumps(combined_list, indent=4)
-final_array_with_url=(convert_json_array_files(json_string,aws_s3_bucketname,aws_s3_dir))
+final_array_with_url=(parse_json_array_convert_base64_to_file_and_upload(json_string,aws_s3_bucketname,aws_s3_dir))
 print(final_array_with_url)
+
 
 with open(json_output, 'w') as f:
     f.write(final_array_with_url)
 
-if aws_secret_access_key != "" and aws_acccess_key_id != "":
+if aws_secret_access_key != "" and aws_access_key_id != "":
 # pending check for existing file list, we will not upload if it exists
-    s3_client = boto3.client(
-        's3',
-        aws_access_key_id=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key
-        )
-    s3_objects = get_s3_objects(bucket_name, s3_client)
+    s3_objects = get_s3_objects(aws_s3_bucketname, s3_client)
     # s3_key should be == to stamps/txid.png
     if s3_key not in s3_objects:
         print(f'Uploading {local_file_path} to {s3_key}')
-        upload_file_to_s3(local_file_path, bucket_name, s3_key, s3_client)
+        upload_file_to_s3_boto3(local_file_path, bucket_name, s3_key, s3_client)
 
 
 if aws_s3_bucketname != "" and aws_s3_dir != "" and aws_cloudfront_distribution_id != "":
-    upload_file_to_s3_aws_cli(json_output,aws_s3_bucketname,"")
+    # upload_file_to_s3_aws_cli(json_output,aws_s3_bucketname,"")
+    upload_file_to_s3_boto3(json_output,aws_s3_bucketname,aws_s3_dir,s3_client)
     # can purge local file upon successful upload
     # os.remove(json_output)
     invalidate_s3_file("/" + json_output)


### PR DESCRIPTION
this prevents duplicates from showing up as additional transactions hit for the same asset - for example a lock.

this version is also checking for a valid Image - this is still up for debate in the final protocol

this change will need further review. we can likely just flatten the message in the process_message function and some other various cleanup.  it's working for now so we'll run with it