### PR TITLE
Stampview profile link extension

### DIFF
--- a/STAMPVIEWER
+++ b/STAMPVIEWER
@@ -79,7 +79,7 @@
 					itemContainer.appendChild(stampInfo);
 					const viewMoreBtn = document.createElement('button');
 					viewMoreBtn.innerText = 'View More';
-					viewMoreBtn.addEventListener('click', () => window.open(`https://xchain.io/asset/${item.asset}`, '_blank'));
+					viewMoreBtn.addEventListener('click', () => window.open(`asset-details.html?stampNumber=${item.stamp}`, '_blank'));
 					itemContainer.appendChild(viewMoreBtn);
 					dataContainer.appendChild(itemContainer);
 					if ((index + 1) % 4 === 0) {
@@ -91,4 +91,3 @@
 	</script>
 </body>
 </html>
-


### PR DESCRIPTION
In this updated code, I've changed the viewMoreBtn event listener to open the asset-details.html page with the corresponding stampNumber in the URL. Make sure that both HTML files (the home page and the asset details page) are in the same directory on your web server or local machine for this to work properly.

These two pages should work together as expected. The home page will display a list of stamps, and when you click "View More" on any of them, it will open the asset details page for the selected stamp in a new tab or window.